### PR TITLE
Closes #4

### DIFF
--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -14,7 +14,7 @@ const (
 
 func NewApp() *cli.App {
 	var certBundlePath string
-	var localCertsPath string
+	var localCertsPath = cli.NewStringSlice()
 
 	app := &cli.App{
 		Name:  "add-ca-certificates",
@@ -26,15 +26,15 @@ func NewApp() *cli.App {
 				Usage:       "Path to the certificate bundle",
 				Destination: &certBundlePath,
 			},
-			&cli.StringFlag{
+			&cli.StringSliceFlag{
 				Name:        "local-path",
-				Value:       LocalCertsPath,
-				Usage:       "Path to the local certificates folder. All certificates in this tree will be trusted.",
-				Destination: &localCertsPath,
+				Value:       cli.NewStringSlice(LocalCertsPath),
+				Usage:       "Path to the local certificates folder. All certificates in this tree will be trusted. Can be specified multiple times.",
+				Destination: localCertsPath,
 			},
 		},
 		Action: func(c *cli.Context) error {
-			manager := management.NewManager(certBundlePath, localCertsPath)
+			manager := management.NewManager(certBundlePath, localCertsPath.Value())
 			err := manager.BuildBundle()
 			if err != nil {
 				return err

--- a/pkg/management/management.go
+++ b/pkg/management/management.go
@@ -11,15 +11,15 @@ import (
 
 type Manager struct {
 	CertBundlePath string
-	LocalPath      string
+	LocalPaths     []string
 
 	certs *certificateSet
 }
 
-func NewManager(certBundle, localPath string) *Manager {
+func NewManager(certBundle string, localPaths []string) *Manager {
 	manager := &Manager{
 		CertBundlePath: certBundle,
-		LocalPath:      localPath,
+		LocalPaths:     localPaths,
 
 		certs: NewCertificateSet(),
 	}
@@ -35,11 +35,16 @@ func (m *Manager) BuildBundle() error {
 	}
 
 	// We use the specific Sub implementation because the fs.Sub one rejects rooted paths, which we support.
-	sub, err := sys.Sub(m.LocalPath)
-	if err != nil {
-		return err
+	for _, localPath := range m.LocalPaths {
+		sub, err := sys.Sub(localPath)
+		if err != nil {
+			return err
+		}
+		if err = m.parseLocalPath(sub); err != nil {
+			return err
+		}
 	}
-	return m.parseLocalPath(sub)
+	return nil
 }
 
 func (m *Manager) WriteBundle() (int64, error) {


### PR DESCRIPTION
Allows `local-path` to be specified multiple times